### PR TITLE
Adding string literal to Rf_error

### DIFF
--- a/src/zip_compression.cpp
+++ b/src/zip_compression.cpp
@@ -10,7 +10,6 @@ void _zip_error(const char *txt, const char *err, int infd, int outfd)
 {
     close(infd);
     close(outfd);
-    Rf_error(txt,
     err ? Rf_error(txt, err) : Rf_error("%s", txt);
 }
 

--- a/src/zip_compression.cpp
+++ b/src/zip_compression.cpp
@@ -10,7 +10,8 @@ void _zip_error(const char *txt, const char *err, int infd, int outfd)
 {
     close(infd);
     close(outfd);
-    err ? Rf_error("%s", txt, err) : Rf_error("%s", txt);
+    Rf_error(txt,
+    err ? Rf_error(txt, err) : Rf_error("%s", txt);
 }
 
 void _zip_open(std::string input_file_path, std::string output_file_path, int *infd, int *outfd, bool append)

--- a/src/zip_compression.cpp
+++ b/src/zip_compression.cpp
@@ -10,7 +10,7 @@ void _zip_error(const char *txt, const char *err, int infd, int outfd)
 {
     close(infd);
     close(outfd);
-    err ? Rf_error(txt, err) : Rf_error(txt);
+    err ? Rf_error("%s", txt, err) : Rf_error("%s", txt);
 }
 
 void _zip_open(std::string input_file_path, std::string output_file_path, int *infd, int *outfd, bool append)


### PR DESCRIPTION
If you follow the current instructions to install with R it will fail with the following error:

```
zip_compression.cpp: In function ‘void _zip_error(const char*, const char*, int, int)’:
zip_compression.cpp:13:44: error: format not a string literal and no format arguments [-Werror=format-security]
   13 |     err ? Rf_error(txt, err) : Rf_error(txt);
      |                                            ^
```

The change resolves that issue.